### PR TITLE
fix: ensure staffer image dimensions and aspect ratio

### DIFF
--- a/_sass/custom/staffer.scss
+++ b/_sass/custom/staffer.scss
@@ -5,7 +5,9 @@
   .staffer-image {
     border-radius: 50%;
     height: 100px;
+    width: 100px;
     margin-right: $sp-4;
+    object-fit: cover;
   }
 
   p,


### PR DESCRIPTION
For non-square staffer images, the old CSS rules create an oval shape that's inconsistent with the square images. For instance:

<img width="401" alt="image" src="https://user-images.githubusercontent.com/11740102/149819449-98687e26-e9b5-452a-add5-8ac95cda0c0a.png">

This PR adds two rules that restricts the image height to be `100px` and avoid stretching the source image with `object-fit: cover`.

## Example

<img width="449" alt="image" src="https://user-images.githubusercontent.com/11740102/149819595-ff314472-5217-4187-8b52-c906c479446e.png">
