### PR TITLE
fix: resource page title

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -6,7 +6,7 @@ has_children: false
 nav_order: 2
 ---
 
-#Resources
+# Resources
 
 ## git/GitHub
 


### PR DESCRIPTION
Fix `#Resources` so it formats in markdown.