### PR TITLE
docs: add calendar and weekly schedule

### DIFF
--- a/_modules/week-01.md
+++ b/_modules/week-01.md
@@ -2,28 +2,25 @@
 title: Tentative schedule, topic may change
 ---
 
-TBD
-
-
-<!-- Feb 2 (Tue)
+Jan 18 (Tue)
 : Intro
 
-Feb 4 (Thur)
+Jan 20 (Thur)
 : VCS, Code Editing and Running
 
-Feb 5 (Fri)
-: **Recitation**{: .label .label-purple } Git/GitHub/submitting and assignment
+Jan 21 (Fri)
+: **Recitation**{: .label .label-purple } `git`/GitHub/submitting and assignment
 
-Feb 9 (Tue)
+Jan 25 (Tue)
 : File I/O **[HW1](https://cmu-crafting-software.github.io//assignments/hw1) due**{: .label .label-red }
 
-Feb 11 (Thur)
+Jan 27 (Thur)
 : Paths and directory navigation
 
-Feb 12 (Fri)
-: **Recitation**{: .label .label-purple } WebAPIs, REST
+Jan 28 (Fri)
+: **Recitation**{: .label .label-purple } Web APIs, REST
 
-Feb 16 (Tue)
+<!-- Feb 16 (Tue)
 : Intro to Testing: Edge Cases, Coverage
 
 Feb 18 (Thur)
@@ -131,4 +128,4 @@ May 7 (Fri)
 : **Recitation**{: .label .label-purple } Final Project Check-in Meetings
 
 TBD:
-: **Final**{: .label .label-green } Final Project Presentation -->
+: **Final**{: .label .label-green } Final Project Presentation --> 

--- a/_schedules/weekly.md
+++ b/_schedules/weekly.md
@@ -1,0 +1,42 @@
+---
+timeline:
+  - '9:00 AM'
+  - '9:30 AM'
+  - '10:00 AM'
+  - '10:30 AM'
+  - '11:00 AM'
+  - '11:30 AM'
+  - '12:00 PM'
+  - '12:30 PM'
+  - '1:00 PM'
+  - '1:30 PM'
+  - '2:00 PM'
+  - '2:30 PM'
+  - '3:00 PM'
+  - '3:30 PM'
+  - '4:00 PM'
+  - '4:30 PM'
+  - '5:00 PM'
+  - '5:30 PM'
+schedule:
+  - name: Monday
+  - name: Tuesday
+    events:
+        - name: Lecture
+          start: 3:05 PM
+          end: 4:25 PM
+          location: WEH 6423
+  - name: Wednesday
+  - name: Thursday
+    events:
+        - name: Lecture
+          start: 3:05 PM
+          end: 4:25 PM
+          location: WEH 6423
+  - name: Friday
+    events:
+      - name: Recitation
+        start: 2:30 PM
+        end: 3:20 PM
+        location: WEH 5310
+---

--- a/schedule.md
+++ b/schedule.md
@@ -1,0 +1,11 @@
+---
+layout: page
+title: Schedule
+description: The weekly event schedule.
+---
+
+# Weekly Schedule
+
+{% for schedule in site.schedules %}
+{{ schedule }}
+{% endfor %}


### PR DESCRIPTION
The 2021 website is missing the weekly schedule page and course calendar. This PR adds them back in and update the calendar with this semester's schedule.